### PR TITLE
Fix command ID issues in message handlers

### DIFF
--- a/src/main/java/com/fattahpour/uap/messages/UssdBindResp.java
+++ b/src/main/java/com/fattahpour/uap/messages/UssdBindResp.java
@@ -17,7 +17,9 @@ public class UssdBindResp extends MessageBase {
     public UssdBindResp(byte[] message) {
         this.Message = message;
         this.dencode();
-        this.CommandID = CommandIDs.UssdUnBindResp;
+        // The response to a bind operation should carry the UssdBindResp ID.
+        // Previously this was incorrectly set to UssdUnBindResp.
+        this.CommandID = CommandIDs.UssdBindResp;
     }
 
     @Override

--- a/src/main/java/com/fattahpour/uap/messages/UssdChargeIndResp.java
+++ b/src/main/java/com/fattahpour/uap/messages/UssdChargeIndResp.java
@@ -12,7 +12,9 @@ package com.fattahpour.uap.messages;
 public class UssdChargeIndResp extends MessageBase {
 
     public UssdChargeIndResp() {
-    this.CommandID = CommandIDs.UssdBindResp;
+        // Charge indication responses should use the UssdChargeIndResp ID.
+        // It was previously set to UssdBindResp, which was incorrect.
+        this.CommandID = CommandIDs.UssdChargeIndResp;
     }
     
 }

--- a/src/main/java/com/fattahpour/uap/messages/UssdContinue.java
+++ b/src/main/java/com/fattahpour/uap/messages/UssdContinue.java
@@ -27,7 +27,9 @@ public class UssdContinue extends MessageBase {
     public UssdContinue(byte[] message) {
         this.Message = message;
         this.dencode();
-        this.CommandID = CommandIDs.UssdBegin;
+        // After decoding we should preserve the original command type.
+        // Setting this to UssdBegin prevented proper message identification.
+        this.CommandID = CommandIDs.UssdContinue;
     }
 
     @Override
@@ -37,7 +39,11 @@ public class UssdContinue extends MessageBase {
         this.UssdVersion = UssdVersions.fromInteger(Arrays.copyOfRange(this.Message, 20, 21)[0]);
         this.UssdOpType = UssdOpTypes.fromInteger(Arrays.copyOfRange(this.Message, 21, 22)[0]);
         this.MsIsdn = StringUtility.GetCOctetStringFromBytes(Arrays.copyOfRange(this.Message, 22, 43));
-        this.ServiceCode = 987;
+        // Parse the service code from the incoming bytes instead of using a
+        // hard coded value.
+        this.ServiceCode = Integer.parseInt(
+                StringUtility.GetCOctetStringFromBytes(
+                        Arrays.copyOfRange(this.Message, 43, 47)));
         this.CodeScheme = CodeSchemes.fromInteger(Arrays.copyOfRange(this.Message, 47, 48)[0]);
         this.UssdString = StringUtility.GetCOctetStringFromBytes(Arrays.copyOfRange(this.Message, 48, this.CommandLength));
 

--- a/src/test/java/com/fattahpour/uap/messages/TestMessages.java
+++ b/src/test/java/com/fattahpour/uap/messages/TestMessages.java
@@ -15,14 +15,11 @@ public class TestMessages {
     
     
     @Test
-    public void UssdBegin()
-    {
-         UssdBind bind = new UssdBind();
-         bind.encode();
-         
-         
-         
-         
-         
+    public void validateCommandIds() {
+        UssdBindResp bindResp = new UssdBindResp(new byte[20]);
+        assert(bindResp.getCommandID() == CommandIDs.UssdBindResp);
+
+        UssdChargeIndResp chargeResp = new UssdChargeIndResp();
+        assert(chargeResp.getCommandID() == CommandIDs.UssdChargeIndResp);
     }
 }


### PR DESCRIPTION
## Summary
- correct `CommandID` values in several message classes
- parse service code correctly in `UssdContinue`
- update small unit test to ensure IDs are set properly

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fa6bca6cc8329a36af97cd4904e4d