### PR TITLE
Fix constructor comment and remove outdated reference

### DIFF
--- a/src/main/java/com/fattahpour/uap/messages/UssdEnd.java
+++ b/src/main/java/com/fattahpour/uap/messages/UssdEnd.java
@@ -19,7 +19,6 @@ public class UssdEnd extends MessageBase {
     public UssdEnd() {
         this.CommandID = CommandIDs.UssdEnd;
         this.UssdOpType = UssdOpTypes.Response;
-        //ussdContinue.setUssdOpType(UssdOpTypes.Response);
     }
 
     public UssdVersions getUssdVersion() {


### PR DESCRIPTION
## Summary
- remove obsolete comment referencing `ussdContinue` in `UssdEnd`

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fa8930bb08329a8bf02897f44e0b2