### PR TITLE
Fix command ID in UssdBindResp constructor

### DIFF
--- a/src/main/java/com/fattahpour/uap/messages/UssdBindResp.java
+++ b/src/main/java/com/fattahpour/uap/messages/UssdBindResp.java
@@ -18,7 +18,8 @@ public class UssdBindResp extends MessageBase {
         this.Message = message;
         this.dencode();
         // The response to a bind operation should carry the UssdBindResp ID.
-        // Previously this was incorrectly set to UssdUnBindResp.
+        // Previously this value was incorrectly set to UssdUnBindResp.
+        // Setting it here ensures the command is recognized correctly.
         this.CommandID = CommandIDs.UssdBindResp;
     }
 


### PR DESCRIPTION
## Summary
- clarify comment for setting `UssdBindResp` command ID

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fa88bc2dc8329ac1c6812afae22d6