### PR TITLE
Rename dencode() to decode()

### DIFF
--- a/src/main/java/com/fattahpour/uap/messages/MessageBase.java
+++ b/src/main/java/com/fattahpour/uap/messages/MessageBase.java
@@ -124,7 +124,12 @@ public abstract class MessageBase {
 
     }
 
-    protected boolean dencode() {
+    /**
+     * Decode the raw message bytes and populate the object's fields.
+     *
+     * @return {@code true} if decoding succeeds, otherwise {@code false}.
+     */
+    protected boolean decode() {
         if (this.headerDecode()) {
             return true;
         } else {

--- a/src/main/java/com/fattahpour/uap/messages/UssdBegin.java
+++ b/src/main/java/com/fattahpour/uap/messages/UssdBegin.java
@@ -17,13 +17,13 @@ public class UssdBegin extends MessageBase {
 
     public UssdBegin(byte[] message) {
         this.Message = message;
-        this.dencode();
+        this.decode();
         this.CommandID = CommandIDs.UssdBegin;
     }
 
     @Override
-    protected boolean dencode() {
-        super.dencode();
+    protected boolean decode() {
+        super.decode();
         this.UssdVersion = UssdVersions.fromInteger(Arrays.copyOfRange(this.Message, 20, 21)[0]);
         this.UssdOpType = UssdOpTypes.fromInteger(Arrays.copyOfRange(this.Message, 21, 22)[0]);
         this.MsIsdn = StringUtility.GetCOctetStringFromBytes(Arrays.copyOfRange(this.Message, 22, 43));

--- a/src/main/java/com/fattahpour/uap/messages/UssdBindResp.java
+++ b/src/main/java/com/fattahpour/uap/messages/UssdBindResp.java
@@ -16,15 +16,15 @@ public class UssdBindResp extends MessageBase {
 
     public UssdBindResp(byte[] message) {
         this.Message = message;
-        this.dencode();
+        this.decode();
         // The response to a bind operation should carry the UssdBindResp ID.
         // Previously this was incorrectly set to UssdUnBindResp.
         this.CommandID = CommandIDs.UssdBindResp;
     }
 
     @Override
-    protected boolean dencode() {
-        super.dencode(); //To change body of generated methods, choose Tools | Templates.
+    protected boolean decode() {
+        super.decode(); //To change body of generated methods, choose Tools | Templates.
         this.AccountName = StringUtility.GetCOctetStringFromBytes(this.Message, 20, 11);
         return true;
         

--- a/src/main/java/com/fattahpour/uap/messages/UssdContinue.java
+++ b/src/main/java/com/fattahpour/uap/messages/UssdContinue.java
@@ -26,15 +26,15 @@ public class UssdContinue extends MessageBase {
 
     public UssdContinue(byte[] message) {
         this.Message = message;
-        this.dencode();
+        this.decode();
         // After decoding we should preserve the original command type.
         // Setting this to UssdBegin prevented proper message identification.
         this.CommandID = CommandIDs.UssdContinue;
     }
 
     @Override
-    protected boolean dencode() {
-        super.dencode(); //To change body of generated methods, choose Tools | Templates.
+    protected boolean decode() {
+        super.decode(); //To change body of generated methods, choose Tools | Templates.
 
         this.UssdVersion = UssdVersions.fromInteger(Arrays.copyOfRange(this.Message, 20, 21)[0]);
         this.UssdOpType = UssdOpTypes.fromInteger(Arrays.copyOfRange(this.Message, 21, 22)[0]);

--- a/src/main/java/com/fattahpour/uap/messages/UssdShakeResp.java
+++ b/src/main/java/com/fattahpour/uap/messages/UssdShakeResp.java
@@ -13,13 +13,13 @@ public class UssdShakeResp extends MessageBase {
 
     public UssdShakeResp(byte[] message) {
         this.Message = message;
-        this.dencode();
+        this.decode();
         this.CommandID = CommandIDs.UssdShakeResp;
     }
 
     @Override
-    protected boolean dencode() {
-        super.dencode();
+    protected boolean decode() {
+        super.decode();
         return true;
     }
 

--- a/src/main/java/com/fattahpour/uap/messages/UssdUnBindResp.java
+++ b/src/main/java/com/fattahpour/uap/messages/UssdUnBindResp.java
@@ -16,8 +16,8 @@ public class UssdUnBindResp extends MessageBase {
     }
 
     @Override
-    protected boolean dencode() {
-        return super.dencode(); //To change body of generated methods, choose Tools | Templates.
+    protected boolean decode() {
+        return super.decode(); //To change body of generated methods, choose Tools | Templates.
     }
     
 


### PR DESCRIPTION
## Summary
- rename `dencode()` to `decode()` in `MessageBase`
- override `decode()` in all subclasses and update constructor calls

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fa880cd948329a2cbf4588a51331d