### PR TITLE
Add encode validation for UssdBind

### DIFF
--- a/src/test/java/com/fattahpour/uap/messages/TestMessages.java
+++ b/src/test/java/com/fattahpour/uap/messages/TestMessages.java
@@ -6,6 +6,8 @@
 package com.fattahpour.uap.messages;
 
 import org.junit.Test;
+import java.util.Arrays;
+import com.fattahpour.uap.utility.IntUtility;
 
 /**
  *
@@ -21,5 +23,18 @@ public class TestMessages {
 
         UssdChargeIndResp chargeResp = new UssdChargeIndResp();
         assert(chargeResp.getCommandID() == CommandIDs.UssdChargeIndResp);
+    }
+
+    @Test
+    public void encodeBindMessage() {
+        UssdBind bind = new UssdBind();
+        byte[] encoded = bind.encode();
+
+        assert(encoded != null);
+        int length = IntUtility.toInt(Arrays.copyOfRange(encoded, 0, 4));
+        assert(length == encoded.length);
+
+        int command = IntUtility.toInt(Arrays.copyOfRange(encoded, 4, 8));
+        assert(command == CommandIDs.UssdBind.toInt());
     }
 }


### PR DESCRIPTION
## Summary
- enhance `TestMessages` to verify `UssdBind.encode()` output

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fa896689c8329bb4467efad30109a