### PR TITLE
Improve bind encode test

### DIFF
--- a/src/test/java/com/fattahpour/uap/messages/TestMessages.java
+++ b/src/test/java/com/fattahpour/uap/messages/TestMessages.java
@@ -8,6 +8,7 @@ package com.fattahpour.uap.messages;
 import org.junit.Test;
 import java.util.Arrays;
 import com.fattahpour.uap.utility.IntUtility;
+import static org.junit.Assert.*;
 
 /**
  *
@@ -19,10 +20,10 @@ public class TestMessages {
     @Test
     public void validateCommandIds() {
         UssdBindResp bindResp = new UssdBindResp(new byte[20]);
-        assert(bindResp.getCommandID() == CommandIDs.UssdBindResp);
+        assertEquals(CommandIDs.UssdBindResp, bindResp.getCommandID());
 
         UssdChargeIndResp chargeResp = new UssdChargeIndResp();
-        assert(chargeResp.getCommandID() == CommandIDs.UssdChargeIndResp);
+        assertEquals(CommandIDs.UssdChargeIndResp, chargeResp.getCommandID());
     }
 
     @Test
@@ -30,11 +31,21 @@ public class TestMessages {
         UssdBind bind = new UssdBind();
         byte[] encoded = bind.encode();
 
-        assert(encoded != null);
+        assertNotNull("Encoded bind message should not be null", encoded);
         int length = IntUtility.toInt(Arrays.copyOfRange(encoded, 0, 4));
-        assert(length == encoded.length);
+        assertEquals("Message length field", encoded.length, length);
 
         int command = IntUtility.toInt(Arrays.copyOfRange(encoded, 4, 8));
-        assert(command == CommandIDs.UssdBind.toInt());
+        assertEquals(CommandIDs.UssdBind.toInt(), command);
+
+        // Decode header back using a simple MessageBase subclass
+        DummyMessage decoded = new DummyMessage(encoded);
+        assertTrue(decoded.decode());
+        assertEquals(CommandIDs.UssdBind, decoded.getCommandID());
+    }
+
+    private static class DummyMessage extends MessageBase {
+        DummyMessage(byte[] message) { this.Message = message; }
+        public boolean decode() { return super.decode(); }
     }
 }


### PR DESCRIPTION
## Summary
- use junit assertions in `TestMessages`
- verify encoded length field and command id
- decode encoded message using a helper class to check header

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_684316fa1c388329afb00786f98e1134