### PR TITLE
Fix comments for UssdEnd

### DIFF
--- a/src/main/java/com/fattahpour/uap/messages/UssdEnd.java
+++ b/src/main/java/com/fattahpour/uap/messages/UssdEnd.java
@@ -1,18 +1,11 @@
 package com.fattahpour.uap.messages;
 
-/*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
- */
-
 import com.fattahpour.uap.utility.StringUtility;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
 /**
- *
- * @author Ghasem Fattahpour
+ * Represents a USSD End message which terminates an interactive USSD session.
  */
 public class UssdEnd extends MessageBase {
 


### PR DESCRIPTION
## Summary
- remove obsolete template header in `UssdEnd`
- describe `UssdEnd` class with a short Javadoc comment

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_684316f8b9e0832980bce746064c9b29